### PR TITLE
signable improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,13 +73,13 @@ class Hypersign {
       Buffer.from(`${salt.length}:`),
       salt,
       seqSeg,
-      Buffer.from(seq.toString()),
+      Buffer.from(`${seq.toString()}e`),
       vSeg,
       Buffer.from(`${value.length}:`),
       value
     ]) : Buffer.concat([
       seqSeg,
-      Buffer.from(seq.toString()),
+      Buffer.from(`${seq.toString()}e`),
       vSeg,
       Buffer.from(`${value.length}:`),
       value

--- a/index.js
+++ b/index.js
@@ -9,12 +9,14 @@ const {
   crypto_sign_BYTES: signSize,
   randombytes_buf: randomBytes
 } = require('sodium-universal')
-const uint64be = require('uint64be')
-const bencode = require('bencode')
 
 // VALUE_MAX_SIZE + packet overhead (i.e. the key etc.)
 // should be less than the network MTU, normally 1400 bytes
 const VALUE_MAX_SIZE = 1000
+
+const saltSeg = Buffer.from('4:salt')
+const seqSeg = Buffer.from('3:seqi')
+const vSeg = Buffer.from('1:v')
 
 class Hypersign {
   salt (str = null, size = 32) {
@@ -55,23 +57,31 @@ class Hypersign {
   }
 
   signable (value, opts = {}) {
-    const { salt = Buffer.alloc(0), seq = 0, encoding = '' } = opts
+    const { salt, seq = 0 } = opts
     assert(Buffer.isBuffer(value), 'Value must be a buffer')
     assert(value.length <= VALUE_MAX_SIZE, `Value size must be <= ${VALUE_MAX_SIZE}`)
-    if (salt.length > 0) {
+    if (salt) {
       assert(Buffer.isBuffer(salt), 'salt must be a buffer')
       assert(
         salt.length <= 64,
         'salt size must be no greater than 64 bytes'
       )
     }
-    if (encoding === 'bencode') {
-      return bencode.encode({ seq, v: value, salt }).slice(1, -1)
-    }
-    return Buffer.concat([
-      uint64be.encode(seq),
-      Buffer.from([salt.length]),
+
+    return salt ? Buffer.concat([
+      saltSeg,
+      Buffer.from(`${salt.length}:`),
       salt,
+      seqSeg,
+      Buffer.from(seq.toString()),
+      vSeg,
+      Buffer.from(`${value.length}:`),
+      value
+    ]) : Buffer.concat([
+      seqSeg,
+      Buffer.from(seq.toString()),
+      vSeg,
+      Buffer.from(`${value.length}:`),
       value
     ])
   }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Utility methods related to public key cryptography to be used with distributed mutable storage",
   "main": "index.js",
   "dependencies": {
-    "bencode": "^2.0.1",
-    "sodium-universal": "^2.0.0",
-    "uint64be": "^2.0.2"
+    "sodium-universal": "^2.0.0"
   },
   "devDependencies": {
     "standard": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,17 @@
   "description": "Utility methods related to public key cryptography to be used with distributed mutable storage",
   "main": "index.js",
   "dependencies": {
-    "sodium-universal": "^2.0.0"
+    "bencode": "^2.0.1",
+    "sodium-universal": "^2.0.0",
+    "uint64be": "^2.0.2"
   },
   "devDependencies": {
     "standard": "^13.1.0",
     "tap": "^14.5.0"
   },
   "scripts": {
-    "test": "tap  -R classic test/*.test.js  && standard --fix",
-    "cov": "tap -R classic --100 test/*.test.js",
+    "test": "tap --no-esm  -R classic test/*.test.js  && standard --fix",
+    "cov": "tap --no-esm -R classic --100 test/*.test.js",
     "ci": "standard && npm run cov"
   },
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ const {
   crypto_generichash: hash
 } = require('sodium-universal')
 const hypersign = require('../')()
-
+const bencode = require('bencode')
 test('keypair', async ({ is }) => {
   const { publicKey, secretKey } = hypersign.keypair()
   is(publicKey instanceof Buffer, true)
@@ -38,11 +38,46 @@ test('salt string', async ({ is, throws }) => {
 test('signable', async ({ is, same }) => {
   const salt = hypersign.salt()
   const value = Buffer.from('test')
-  is(hypersign.signable(value), value)
-  is(hypersign.signable(value, { seq: 1 }), value)
+  same(
+    hypersign.signable(value),
+    Buffer.concat([
+      Buffer.alloc(9),
+      value
+    ])
+  )
+  same(
+    hypersign.signable(value, { seq: 1 }),
+    Buffer.concat([
+      Buffer.concat([Buffer.alloc(7), Buffer.alloc(1, 1)]),
+      Buffer.alloc(1),
+      value
+    ])
+  )
   same(
     hypersign.signable(value, { salt }),
-    Buffer.concat([Buffer.from([salt.length]), salt, value])
+    Buffer.concat([
+      Buffer.concat([Buffer.alloc(7), Buffer.alloc(1)]),
+      Buffer.from([salt.length]),
+      salt,
+      value
+    ])
+  )
+})
+
+test('signable bencode encoding', async ({ is, same }) => {
+  const salt = hypersign.salt()
+  const value = Buffer.from('test')
+  same(
+    hypersign.signable(value, { encoding: 'bencode' }),
+    bencode.encode({ seq: 0, v: value, salt: Buffer.alloc(0) }).slice(1, -1)
+  )
+  same(
+    hypersign.signable(value, { seq: 1, encoding: 'bencode' }),
+    bencode.encode({ seq: 1, v: value, salt: Buffer.alloc(0) }).slice(1, -1)
+  )
+  same(
+    hypersign.signable(value, { salt, encoding: 'bencode' }),
+    bencode.encode({ seq: 0, v: value, salt }).slice(1, -1)
   )
 })
 
@@ -50,14 +85,10 @@ test('mutable signable - salt must be a buffer', async ({ throws }) => {
   throws(() => hypersign.signable(Buffer.from('test'), { salt: 'no' }), 'salt must be a buffer')
 })
 
-test('mutable signable - salt size must be >= 16 bytes and <= 64 bytes', async ({ throws }) => {
-  throws(
-    () => hypersign.signable(Buffer.from('test'), { salt: Buffer.alloc(15) }),
-    'salt size must be between 16 and 64 bytes (inclusive)'
-  )
+test('mutable signable - salt size must be no greater than 64 bytes', async ({ throws }) => {
   throws(
     () => hypersign.signable(Buffer.from('test'), { salt: Buffer.alloc(65) }),
-    'salt size must be between 16 and 64 bytes (inclusive)'
+    'salt size must be no greater than 64 bytes'
   )
 })
 
@@ -74,18 +105,65 @@ test('mutable signable - value size must be <= 1000 bytes', async ({ throws }) =
   )
 })
 
-test('sign', async ({ is, throws }) => {
+test('sign', async ({ is }) => {
   const keypair = hypersign.keypair()
   const { publicKey } = keypair
   const salt = hypersign.salt()
   const value = Buffer.from('test')
-  const signable = hypersign.signable(value, { salt })
   is(
-    verify(hypersign.sign(value, { keypair }), value, publicKey),
+    verify(
+      hypersign.sign(value, { keypair }),
+      hypersign.signable(value),
+      publicKey
+    ),
     true
   )
   is(
-    verify(hypersign.sign(value, { salt, keypair }), signable, publicKey),
+    verify(
+      hypersign.sign(value, { salt, keypair }),
+      hypersign.signable(value, { salt }),
+      publicKey
+    ),
+    true
+  )
+  is(
+    verify(
+      hypersign.sign(value, { seq: 2, keypair }),
+      hypersign.signable(value, { seq: 2 }),
+      publicKey
+    ),
+    true
+  )
+})
+
+test('sign - bencode encoding', async ({ is }) => {
+  const keypair = hypersign.keypair()
+  const { publicKey } = keypair
+  const salt = hypersign.salt()
+  const value = Buffer.from('test')
+  const encoding = 'bencode'
+  is(
+    verify(
+      hypersign.sign(value, { keypair, encoding }),
+      hypersign.signable(value, { encoding }),
+      publicKey
+    ),
+    true
+  )
+  is(
+    verify(
+      hypersign.sign(value, { salt, keypair, encoding }),
+      hypersign.signable(value, { salt, encoding }),
+      publicKey
+    ),
+    true
+  )
+  is(
+    verify(
+      hypersign.sign(value, { seq: 2, keypair, encoding }),
+      hypersign.signable(value, { seq: 2, encoding }),
+      publicKey
+    ),
     true
   )
 })


### PR DESCRIPTION
* introduces bencode option
* includes seq in default "encoding"

question: is "encoding" the right word here?

## Why use bencode?

For compatibility with API's/CLI's migrating from bittorrent-dht

## Why not just use bencode?

It depends on whether 2x performance difference is significant. For heavy mutable I/O it could be...

bench.js
```js
'use strict'
const hypersign = require('.')()
const salt = hypersign.salt()
const value = Buffer.from('test')

var i = 10000
var x = Buffer.alloc(0)

console.time('default encoding')
while (i--) x = hypersign.signable(value, { salt })
console.timeEnd('default encoding')
i = 10000
x = Buffer.alloc(0)
console.time('bencode encoding')
while (i--) x = hypersign.signable(value, { salt, encoding: 'bencode' })
console.timeEnd('bencode encoding')
```

![image](https://user-images.githubusercontent.com/1190716/63880016-2ce20780-c9cd-11e9-875a-32fffc268b46.png)
