### PR TITLE
Add typings to Hypersign

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Utility method for creating a random or hashed salt value.
 If called with a string the string will be hashed, to a
 generic hash of `size` length.
 
-If called without any inputs, or with a number, random 
-butes of `size` length will be
+If called without any inputs, or with a number, random
+bytes of `size` length will be returned
 
 #### `sign(value, options)`
 
@@ -43,7 +43,7 @@ Options:
 #### `signable(value, options)`
 
 Utility method which returns the exact buffer that would be signed in by `sign`. This is only needed when using a salt, otherwise it will return the same `value` passed in. This method is to facilitate out-of-band signing (e.g. hardware signing), do not pass the returned signable value into `sign`, it already uses `signable`.
-If you need to sign a value that has already been passed 
+If you need to sign a value that has already been passed
 through `signable`, use `cryptoSign`.
 
 Options:
@@ -53,7 +53,7 @@ Options:
 
 #### `cryptoSign(msg, keypair)`
 
-Utility method which can be used to create a signature using the `crypto_sign_detached` Sodium method. This only needs to be used 
+Utility method which can be used to create a signature using the `crypto_sign_detached` Sodium method. This only needs to be used
 when you *do not* need to apply encoding to `value`, `salt` and `seq`(e.g. if value and options have already been passed to `signable`).
 
 Options:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+declare function _exports(): Hypersign;
+export default _exports;
+export { Hypersign }
+/** VALUE_MAX_SIZE + packet overhead (i.e. the key etc.) should be less than the network MTU, normally 1400 bytes */
+export const VALUE_MAX_SIZE: number;
+
+export declare interface KeyPair {
+  publicKey:Buffer
+  secretKey:Buffer
+}
+
+declare interface SignOptions {
+  keypair?: KeyPair
+  salt?:Buffer
+  seq?:number
+}
+
+declare class Hypersign {
+  /** Utility method for creating a random or hashed salt value. If called with a string the string will be hashed, to a generic hash of size length. If called without any inputs, or with a number, random býtes of size length will be returned */
+  salt(str?: string, size?: number): Buffer;
+  /** Use this method to generate an assymetric keypair. Returns an object with {publicKey, secretKey}. publicKey holds a public key buffer, secretKey holds a private key buffer. */
+  keypair(): KeyPair
+  /** Utility method which can be used to create a signature using the crypto_sign_detached Sodium method. This only needs to be used when you do not need to apply encoding to value, salt and seq(e.g. if value and options have already been passed to signable). */
+  cryptoSign(msg: Buffer, keypair: KeyPair ): Buffer;
+  /** Utility method which can be used to create a signature. */
+  sign(value: Buffer, opts: SignOptions): Buffer;
+  /** Utility method which returns the exact buffer that would be signed in by sign. This is only needed when using a salt, otherwise it will return the same value passed in. */
+  signable(value: Buffer, opts?: { salt?:Buffer, seq?:number }): Buffer;
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "2.1.0",
   "description": "Utility methods related to public key cryptography to be used with distributed mutable storage",
   "main": "index.js",
+  "types":"index.d.ts",
   "dependencies": {
     "sodium-universal": "^2.0.0"
   },
   "devDependencies": {
+    "@types/node": "^13.11.0",
     "bencode": "^2.0.1",
     "standard": "^13.1.0",
     "tap": "^14.5.0"


### PR DESCRIPTION
Adds typings to Hypersign and fixes some Typos in Readme.md
The Declaration File also exports a few interfaces for use in other type declarations
hyperswarm/hyperswarm#55